### PR TITLE
Feat/24 adicao logs deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Este repositório contém a configuração completa de bancos de dados para o pr
 
 * **SQL/**: Scripts para o banco de dados relacional (PostgreSQL).
     * **Modelo/**: Contém o modelo de dados e o script de carga inicial.
-        * `modelo.sql`: Define o esquema do banco de dados com tabelas, chaves primárias, chaves estrangeiras e sequências.
+        * `schema_public.sql`: Define o esquema do banco de dados com tabelas, chaves primárias, chaves estrangeiras e sequências.
         * `data_load.sql`: Script de carga de dados de exemplo para popular as tabelas.
     * **Procedures/**: Procedimentos armazenados para automatizar tarefas.
         * `sp_desativar_empresa_completo.sql`: Um procedimento para desativar uma empresa e todos os seus usuários associados.

--- a/SQL/Modelo/data_load.sql
+++ b/SQL/Modelo/data_load.sql
@@ -2,7 +2,6 @@
 TRUNCATE TABLE public.PlanoPagamento, public.Mensagem, public.Empresa, public.PlanoVantagem, public.Habilidade, public.Setor, public.Usuario, public.HabilidadeUsuario, public.Tarefa, table_log.LogAtribuicaoTarefa, public.Report, public.TarefaHabilidade, public.TarefaUsuario RESTART IDENTITY CASCADE;
 ALTER SEQUENCE public.sq_PlanoPagamento         RESTART WITH 1;
 ALTER SEQUENCE public.sq_Empresa                RESTART WITH 1;
-ALTER SEQUENCE table_log.sq_LogAtribuicaoTarefa RESTART WITH 1;
 ALTER SEQUENCE public.sq_Mensagem               RESTART WITH 1;
 ALTER SEQUENCE public.sq_PlanoVantagem          RESTART WITH 1;
 ALTER SEQUENCE public.sq_Report                 RESTART WITH 1;

--- a/SQL/Modelo/schema_public.sql
+++ b/SQL/Modelo/schema_public.sql
@@ -1,43 +1,13 @@
 --CREATE DATABASE dbKronos;
 -- Limpa DB
-DROP TABLE IF EXISTS public.PlanoPagamento         CASCADE;
-DROP TABLE IF EXISTS public.Empresa                CASCADE;
-DROP TABLE IF EXISTS public.HabilidadeUsuario      CASCADE;
-DROP TABLE IF EXISTS table_log.LogAtribuicaoTarefa CASCADE;
-DROP TABLE IF EXISTS public.Mensagem               CASCADE;
-DROP TABLE IF EXISTS public.PlanoVantagem          CASCADE;
-DROP TABLE IF EXISTS public.Report                 CASCADE;
-DROP TABLE IF EXISTS public.Setor                  CASCADE;
-DROP TABLE IF EXISTS public.Tarefa                 CASCADE;
-DROP TABLE IF EXISTS public.TarefaHabilidade       CASCADE;
-DROP TABLE IF EXISTS public.TarefaUsuario          CASCADE;
-DROP TABLE IF EXISTS public.Usuario                CASCADE;
-DROP TABLE IF EXISTS public.Habilidade             CASCADE;
-DROP TABLE IF EXISTS public.RegistroDAU            CASCADE;
-
-DROP SEQUENCE IF EXISTS public.sq_PlanoPagamento;
-DROP SEQUENCE IF EXISTS public.sq_Empresa;
-DROP SEQUENCE IF EXISTS table_log.sq_LogAtribuicaoTarefa;
-DROP SEQUENCE IF EXISTS public.sq_Mensagem;
-DROP SEQUENCE IF EXISTS public.sq_PlanoVantagem;
-DROP SEQUENCE IF EXISTS public.sq_Report;
-DROP SEQUENCE IF EXISTS public.sq_Setor;
-DROP SEQUENCE IF EXISTS public.sq_Tarefa;
-DROP SEQUENCE IF EXISTS public.sq_Usuario;
-DROP SEQUENCE IF EXISTS public.sq_Habilidade;
-DROP SEQUENCE IF EXISTS public.sq_TarefaUsuario;
-DROP SEQUENCE IF EXISTS public.sq_TarefaHabilidade;
-DROP SEQUENCE IF EXISTS public.sq_HabilidadeUsuario;
-DROP SEQUENCE IF EXISTS public.sq_RegistroDAU;
-
-DROP TYPE IF EXISTS public.TIPO_LOCAL_USO CASCADE;
-DROP TYPE IF EXISTS public.OPCAO_STATUS   CASCADE;
+DROP SCHEMA IF EXISTS public CASCADE;
 
 -- Criações
+CREATE SCHEMA public;
 -- IDs
+
 CREATE SEQUENCE public.sq_PlanoPagamento         START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE public.sq_Empresa                START WITH 1 INCREMENT BY 1;
-CREATE SEQUENCE table_log.sq_LogAtribuicaoTarefa START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE public.sq_Mensagem               START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE public.sq_PlanoVantagem          START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE public.sq_Report                 START WITH 1 INCREMENT BY 1;
@@ -48,7 +18,6 @@ CREATE SEQUENCE public.sq_Habilidade             START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE public.sq_TarefaUsuario          START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE public.sq_TarefaHabilidade       START WITH 1 INCREMENT BY 1;
 CREATE SEQUENCE public.sq_HabilidadeUsuario      START WITH 1 INCREMENT BY 1;
-CREATE SEQUENCE public.sq_RegistroDAU            START WITH 1 INCREMENT BY 1;
 
 -- Types (Para substituit check)
 CREATE TYPE public.TIPO_LOCAL_USO AS ENUM ( 'APP_MOBILE'
@@ -61,6 +30,7 @@ CREATE TYPE public.OPCAO_STATUS   AS ENUM ( 'Pendente'
                                           , 'Cancelada'
                                           , 'Cancelado'
                                           );
+
 
 -- Tabelas sem dependências
 CREATE TABLE public.PlanoPagamento ( nCdPlano BIGINT        NOT NULL DEFAULT NEXTVAL('public.sq_PlanoPagamento')
@@ -160,28 +130,6 @@ CREATE TABLE public.Tarefa ( nCdTarefa         BIGINT        NOT NULL DEFAULT NE
     , dDataConclusao    TIMESTAMP         NULL
     , PRIMARY KEY (nCdTarefa)
     , FOREIGN KEY (nCdUsuarioRelator) REFERENCES public.Usuario (nCdUsuario)
-);
-
-CREATE TABLE public.RegistroDAU ( nCdSessao BIGINT        NOT NULL DEFAULT NEXTVAL('public.sq_RegistroDAU')
-    , nCdUsuario          BIGINT          NOT NULL
-    , dDataEntrada        TIMESTAMPTZ     NOT NULL
-    , dDataSaida          TIMESTAMPTZ         NULL
-    , dUltimoHeartbeat    TIMESTAMPTZ     NOT NULL
-    , cLocalUso           TIPO_LOCAL_USO  NOT NULL
-    , iDuracaoMinutos     INTEGER             NULL
-    , PRIMARY KEY (nCdSessao)
-    , FOREIGN KEY (nCdUsuario) REFERENCES public.Usuario(nCdUsuario)
-);
-
--- Tabelas com dependência de Tarefa e Usuario
-CREATE TABLE table_log.LogAtribuicaoTarefa ( nCdLogAtribuicao  BIGINT        NOT NULL DEFAULT NEXTVAL('table_log.sq_LogAtribuicaoTarefa')
-    , nCdTarefa         BIGINT        NOT NULL
-    , nCdUsuarioAtuante BIGINT        NOT NULL
-    , dRealocacao       DATE          NOT NULL DEFAULT NOW()
-    , cObservacao       VARCHAR(300)  NOT NULL DEFAULT 'Nenhum comentário para a Tarefa'
-    , PRIMARY KEY (nCdLogAtribuicao)
-    , FOREIGN KEY (nCdTarefa)         REFERENCES public.Tarefa (nCdTarefa)
-    , FOREIGN KEY (nCdUsuarioAtuante) REFERENCES public.Usuario (nCdUsuario)
 );
 
 CREATE TABLE public.Report ( nCdReport  BIGINT        NOT NULL DEFAULT NEXTVAL('public.sq_Report')

--- a/SQL/Modelo/schema_table_log.sql
+++ b/SQL/Modelo/schema_table_log.sql
@@ -1,20 +1,33 @@
 -- Reset das tabelas e do esquema
-DROP TABLE IF EXISTS table_log.PlanoPagamento    CASCADE;
-DROP TABLE IF EXISTS table_log.Mensagem          CASCADE;
-DROP TABLE IF EXISTS table_log.Setor             CASCADE;
-DROP TABLE IF EXISTS table_log.Usuario           CASCADE;
-DROP TABLE IF EXISTS table_log.HabilidadeUsuario CASCADE;
-DROP TABLE IF EXISTS table_log.Tarefa            CASCADE;
-DROP TABLE IF EXISTS table_log.AtribuicaoTarefa  CASCADE;
-DROP TABLE IF EXISTS table_log.Report            CASCADE;
-DROP TABLE IF EXISTS table_log.TarefaHabilidade  CASCADE;
-DROP TABLE IF EXISTS table_log.TarefaUsuario     CASCADE;
-DROP SCHEMA IF EXISTS table_log                  CASCADE;
+DROP SCHEMA table_log CASCADE ;
 
--- Criação do Esquema
+-- Criação do SCHEMA table_log
 CREATE SCHEMA table_log;
 
 -- Criação das Tabelas
+CREATE TABLE table_log.RegistroDAU ( nCdSessao           BIGSERIAL       NOT NULL
+                                   , nCdUsuario          BIGINT          NOT NULL
+                                   , dDataEntrada        TIMESTAMPTZ     NOT NULL
+                                   , dDataSaida          TIMESTAMPTZ         NULL
+                                   , dUltimoHeartbeat    TIMESTAMPTZ     NOT NULL
+                                   , cLocalUso           TIPO_LOCAL_USO  NOT NULL
+                                   , iDuracaoMinutos     INTEGER             NULL
+                                   , PRIMARY KEY (nCdSessao)
+                                   , FOREIGN KEY (nCdUsuario) REFERENCES public.Usuario(nCdUsuario)
+                                   );
+
+-- Tabelas com dependência de Tarefa e Usuario
+CREATE TABLE table_log.LogAtribuicaoTarefa ( nCdLogAtribuicao  BIGSERIAL     NOT NULL
+                                           , nCdTarefa         BIGINT        NOT NULL
+                                           , nCdUsuarioAtuante BIGINT        NOT NULL
+                                           , dRealocacao       DATE          NOT NULL DEFAULT NOW()
+                                           , cObservacao       VARCHAR(300)  NOT NULL DEFAULT 'Nenhum comentário para a Tarefa'
+                                           , PRIMARY KEY (nCdLogAtribuicao)
+                                           , FOREIGN KEY (nCdTarefa)         REFERENCES public.Tarefa (nCdTarefa)
+                                           , FOREIGN KEY (nCdUsuarioAtuante) REFERENCES public.Usuario (nCdUsuario)
+                                           );
+
+
 CREATE TABLE table_log.PlanoPagamento ( nCdLog        BIGSERIAL
 	                                  , nCdPlano      BIGINT        NOT NULL 
                                       , cNmPlano      VARCHAR(50)   NOT NULL 
@@ -119,21 +132,11 @@ CREATE TABLE table_log.Tarefa ( nCdLog            BIGSERIAL
                               , iTendencia        INTEGER      NOT NULL
                               , nTempoEstimado    BIGINT       NOT NULL
                               , cDescricao        VARCHAR(255) NOT NULL
-                              , cStatus           VARCHAR(15)  NOT NULL 
+                              , cStatus           OPCAO_STATUS NOT NULL
                               , cOperacao         VARCHAR(50)
                               , dOperacao         TIMESTAMP              														 
                               , PRIMARY KEY (nCdLog)
                               );
-
-CREATE TABLE table_log.AtribuicaoTarefa ( nCdLog
-	                                    , nCdLogAtribuicao  BIGINT NOT NULL 
-                                        , nCdTarefa         BIGINT NOT NULL
-                                        , nCdUsuarioAtuante BIGINT NOT NULL
-                                        , dRealocacao       DATE   NOT NULL 
-                                        , cOperacao         VARCHAR(50)
-                                        , dOperacao         TIMESTAMP              		  
-                                        , PRIMARY KEY (nCdLogAtribuicao)
-                                        );
 
 CREATE TABLE table_log.Report ( nCdLog        BIGSERIAL
 							  , nCdReport     BIGINT       NOT NULL 


### PR DESCRIPTION
## 📝 Descrição

Foi feita a padronização entre os schemas tabela_log e public, alterando nome de arquivos, movendo comandos sql de um arquivo para outro e substituindo alguns types, para seguir um padrão.
Além disso, foi definido que as PK de todas as tabelas no schema tabela_log deve ser BIGSERIAL.

---

## ✅ Checklist

- [x] Código testado localmente
- [x] Nenhum erro no build
- [x] PR está seguindo a estrutura definida
- [ ] Revisado por pelo menos uma pessoa

---

## 📸 Evidências (screenshots, logs, etc)
N/A
---

## 🔥 Impacto no sistema

- Alguma parte crítica foi alterada? Sim
- Pode afetar outras funcionalidades? Não

---

## 🔗 Informações complementares
[MD - Adicionar execução das tabelas do schema log no deploy](https://trello.com/c/fsEwHMOd)
---
